### PR TITLE
[Fixed] Limit nanoS on claimAll

### DIFF
--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -13,6 +13,7 @@ export const reduxModels: RootModel = { wallet, staking };
 
 export interface Wallet extends LumWallet {
     isExtensionImport?: boolean;
+    isNanoS?: boolean;
 }
 
 export interface CommonTransactionProps {

--- a/src/redux/models/wallet.ts
+++ b/src/redux/models/wallet.ts
@@ -4,6 +4,7 @@ import { Window as KeplrWindow } from '@keplr-wallet/types';
 import { LumUtils, LumWalletFactory, LumWallet, LumConstants } from '@lum-network/sdk-javascript';
 
 import TransportWebUsb from '@ledgerhq/hw-transport-webusb';
+import { DeviceModelId } from '@ledgerhq/devices';
 
 import { showErrorToast, showSuccessToast, WalletClient } from 'utils';
 
@@ -89,7 +90,7 @@ export const wallet = createModel<RootModel>()({
         airdrop: null,
     } as WalletState,
     reducers: {
-        signIn(state, wallet: LumWallet, isExtensionImport?: boolean) {
+        signIn(state, wallet: LumWallet, props?: { isExtensionImport?: boolean; isNanoS?: boolean }) {
             return {
                 ...state,
                 currentWallet: {
@@ -101,7 +102,7 @@ export const wallet = createModel<RootModel>()({
                     canChangeAccount: wallet.canChangeAccount,
                     getPublicKey: wallet.getPublicKey,
                     getAddress: wallet.getAddress,
-                    isExtensionImport,
+                    ...props,
                 },
             };
         },
@@ -234,7 +235,7 @@ export const wallet = createModel<RootModel>()({
                     const offlineSigner = await keplrWindow.getOfflineSignerAuto(chainId);
                     const wallet = await LumWalletFactory.fromOfflineSigner(offlineSigner);
                     if (wallet) {
-                        dispatch.wallet.signIn(wallet, true);
+                        dispatch.wallet.signIn(wallet, { isExtensionImport: true });
                         dispatch.wallet.reloadWalletInfos(wallet.getAddress());
                     }
                     return;
@@ -249,6 +250,7 @@ export const wallet = createModel<RootModel>()({
                 let wallet: null | LumWallet = null;
                 let breakLoop = false;
                 let userCancelled = false;
+                let isNanoS = false;
 
                 // 10 sec timeout to let the user unlock his hardware
                 const to = setTimeout(() => (breakLoop = true), 10000);
@@ -260,6 +262,7 @@ export const wallet = createModel<RootModel>()({
                 while (!wallet && !breakLoop) {
                     try {
                         const transport = await TransportWebUsb.create();
+                        isNanoS = transport.deviceModel?.id === DeviceModelId.nanoS;
 
                         //FIXME: Remove ts-ignore
                         wallet = await LumWalletFactory.fromLedgerTransport(
@@ -280,7 +283,7 @@ export const wallet = createModel<RootModel>()({
                 clearTimeout(to);
 
                 if (wallet) {
-                    dispatch.wallet.signIn(wallet);
+                    dispatch.wallet.signIn(wallet, { isNanoS });
                     dispatch.wallet.reloadWalletInfos(wallet.getAddress());
                     return;
                 } else {

--- a/src/screens/Staking/Staking.tsx
+++ b/src/screens/Staking/Staking.tsx
@@ -304,9 +304,16 @@ const Staking = (): JSX.Element => {
 
     const onSubmitGetAllRewards = async (memo: string) => {
         try {
-            const validatorsAddresses = getUserValidators(bondedValidators, [], delegations, rewards).map(
-                (val) => val.operatorAddress,
-            );
+            const validatorsAddresses = getUserValidators(bondedValidators, [], delegations, rewards)
+                .sort((valA, valB) => {
+                    if (valA.reward > valB.reward) {
+                        return -1;
+                    } else if (valA.reward < valB.reward) {
+                        return 1;
+                    }
+                    return 0;
+                })
+                .map((val) => val.operatorAddress);
 
             const getAllRewardsResult = await getAllRewards({
                 from: wallet,

--- a/src/utils/wallet.ts
+++ b/src/utils/wallet.ts
@@ -521,6 +521,7 @@ class WalletClient {
         }
 
         const messages = [];
+        const limit = fromWallet.isNanoS ? 6 : undefined;
         let gas = 140000;
 
         for (const [index, valAdd] of validatorsAddresses.entries()) {
@@ -528,6 +529,7 @@ class WalletClient {
             if (index > 0) {
                 gas += 80000;
             }
+            if (limit && index + 1 === limit) break;
         }
 
         // Define fees


### PR DESCRIPTION
Due to hardware limitations we limit nanoS ledgers to 6 messages max on claimAll rewards